### PR TITLE
chore: Add @method annotation for static log methods

### DIFF
--- a/log/Logger.php
+++ b/log/Logger.php
@@ -6,6 +6,12 @@ use Yii;
 
 /**
  * Logger Utility class.
+ * 
+ * @method static void debug(string $type, string $message, array $details = [])
+ * @method static void info(string $type, string $message, array $details = [])
+ * @method static void warn(string $type, string $message, array $details = [])
+ * @method static void error(string $type, string $message, array $details = [])
+ * @method static void fatal(string $type, string $message, array $details = [])
  */
 class Logger
 {


### PR DESCRIPTION
# Description

chore: Add @method annotation for static log methods 
Float 2 failing CI static analysers due to missing annotation for static log methods
```
Call to an undefined static method float\log\Logger::warn().
```

## Related issues

-

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have reached out to the Platform team to evaluate the impact on CDC-related services and created a release ticket for schema changes (if applicable)
- [ ] My changes when run in my local environment do not generate any new warnings
- [ ] New and existing unit tests pass locally with my changes (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
